### PR TITLE
Add support for building on Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ docker-compose.override.yml
 
 # Backup files
 *.orig
+
+# Nix
+/result
+/.direnv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  openssl,
+  pkg-config,
+}: let
+  toml = (lib.importTOML ./Cargo.toml).package;
+in
+  rustPlatform.buildRustPackage {
+    pname = "furnace";
+    inherit (toml) version;
+
+    nativeBuildInputs = [
+      openssl
+      pkg-config
+    ];
+
+    PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
+
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.intersection (lib.fileset.fromSource (lib.sources.cleanSource ./.)) (
+        lib.fileset.unions [
+          ./Cargo.toml
+          ./Cargo.lock
+          ./src
+          ./tests
+          ./benches
+
+          # For tests and benchmark
+          ./test_model.burn
+        ]
+      );
+    };
+
+    cargoLock.lockFile = ./Cargo.lock;
+
+    meta = {
+      inherit (toml) homepage description;
+      license = lib.licenses.mit;
+      mainProgram = "furnace";
+    };
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
+        system: function nixpkgs.legacyPackages.${system}
+      );
+  in {
+    packages = forAllSystems (pkgs: {
+      furnace = pkgs.callPackage ./default.nix {};
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.furnace;
+    });
+
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        inputsFrom = [self.packages.${pkgs.stdenv.hostPlatform.system}.furnace];
+
+        shellHook = ''
+          export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc}
+        '';
+
+        buildInputs = with pkgs; [
+          clippy
+          rustfmt
+          rust-analyzer
+        ];
+      };
+    });
+
+    overlays.default = final: _: {example = final.callPackage ./default.nix {};};
+  };
+}


### PR DESCRIPTION
A simple [Nix](https://nixos.org/) Flake for Rust development. 
Provides flake outputs: `packages.furnace` and a basic Rust development environment in `devShells.default`.

For anyone with nix installed, simply run:
```shell
nix build
```
And it will output these binaries: 
- `./result/bin/furnace`
- `./result/bin/create_sample_model`

Also runs all tests defined in Cargo.toml

Tested on 
OS: NixOS 25.11
Architecture: `x86_64`