### PR TITLE
docs: update future loadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/Gilfeather/furnace/actions/workflows/ci.yml/badge.svg)](https://github.com/Gilfeather/furnace/actions/workflows/ci.yml)
 [![Binary Size](https://img.shields.io/badge/binary%20size-2.3MB-blue)](https://github.com/Gilfeather/furnace)
-[![Inference Time](https://img.shields.io/badge/inference-~0.5ms-brightgreen)](https://github.com/Gilfeather/furnace)
+[![Inference Time](https://img.shields.io/badge/inference-~0.5ms*-brightgreen)](https://github.com/Gilfeather/furnace)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/Gilfeather/furnace/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Gilfeather/furnace?style=social)](https://github.com/Gilfeather/furnace/stargazers)
 
@@ -63,14 +63,26 @@ curl -X POST http://localhost:3000/predict \
 
 ## 📊 Performance
 
+⚠️ **Important Note**: Current benchmarks are based on a simple MLP model (784→128→10, ~0.5MB). 
+Real-world model performance will vary significantly based on model size and complexity.
+
+### Current Benchmarks (Simple MLP Model)
 | Metric | Value |
 |--------|-------|
 | Binary Size | **2.3MB** |
+| Model Size | **~0.5MB** |
 | Inference Time | **~0.5ms** |
 | Memory Usage | **<50MB** |
 | Startup Time | **<100ms** |
 
-*Tested with MNIST-like model (784→128→10) on standard hardware*
+### 🚧 Planned Benchmarks (Coming Soon)
+| Model Type | Size | Inference Time | Status |
+|------------|------|----------------|---------|
+| ResNet-18 | ~45MB | TBD | 🔄 In Progress |
+| BERT-base | ~110MB | TBD | 📋 Planned |
+| YOLO v8n | ~6MB | TBD | 📋 Planned |
+
+*Current tests: MNIST-like MLP on standard hardware. Production model benchmarks coming soon.*
 
 ## � API Enpdpoints
 


### PR DESCRIPTION
This pull request updates the `README.md` file to enhance clarity and provide additional performance benchmarking details. The changes include a minor edit to an existing badge and the addition of new sections for benchmark information.

### Updates to badges:
* Updated the "Inference Time" badge to include an asterisk, indicating additional context provided later in the document. (`README.md`, [README.mdL5-R5](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5))

### Benchmarking details:
* Added a note clarifying that current benchmarks are based on a simple MLP model and may not reflect real-world performance for larger models. (`README.md`, [README.mdR66-R85](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R85))
* Introduced a new "Planned Benchmarks" section listing upcoming performance metrics for models like ResNet-18, BERT-base, and YOLO v8n, along with their respective statuses. (`README.md`, [README.mdR66-R85](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R85))