### PR TITLE
fix: resolve clippy warnings for format string arguments

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -382,8 +382,7 @@ fn validate_input_security(input_data: &PredictInputData) -> std::result::Result
             for (i, &value) in input.iter().enumerate() {
                 if !value.is_finite() {
                     return Err(format!(
-                        "Invalid value at index {}: {} (NaN or infinite values not allowed)",
-                        i, value
+                        "Invalid value at index {i}: {value} (NaN or infinite values not allowed)"
                     ));
                 }
             }
@@ -413,8 +412,7 @@ fn validate_input_security(input_data: &PredictInputData) -> std::result::Result
                 for (i, &value) in input.iter().enumerate() {
                     if !value.is_finite() {
                         return Err(format!(
-                            "Invalid value in batch item {} at index {}: {} (NaN or infinite values not allowed)",
-                            batch_idx, i, value
+                            "Invalid value in batch item {batch_idx} at index {i}: {value} (NaN or infinite values not allowed)"
                         ));
                     }
                 }


### PR DESCRIPTION
## 🔧 Clippy Warning Fix

This PR resolves clippy warnings that were introduced with the security improvements.

## 🐛 Problem
After merging the security improvements, CI started failing due to clippy warnings:
- clippy::uninlined_format_args warnings in security validation error messages
- Format strings using old syntax: format!("...", var)

## 🔧 Solution
- Update format string syntax to use inline arguments
- Change format!("Invalid value at index {}: {}", i, value) 
- To format!("Invalid value at index {i}: {value}")
- Apply to both single input and batch input validation error messages

## 📋 Changes
- src/api.rs: Update 2 format string calls to use inline arguments
- Maintains exact same functionality and error message content
- Follows current Rust formatting best practices

## ✅ Testing
- ✅ Clippy passes: cargo clippy --all-targets --all-features -- -D warnings
- ✅ Compilation successful
- ✅ No functional changes to security validation logic
- ✅ Error messages remain identical for users

## 🎯 Impact
- Resolves CI clippy failures
- Ensures code follows modern Rust formatting standards
- No impact on functionality or user experience
- Maintains all security validation behavior

This is a pure code style fix with no functional changes.